### PR TITLE
refact: 매칭 요청을 Redis 메시지 큐로 비동기 처리

### DIFF
--- a/m-common/src/main/java/com/antmen/antwork/common/api/request/reservation/MatchingRequestDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/request/reservation/MatchingRequestDto.java
@@ -1,23 +1,32 @@
 package com.antmen.antwork.common.api.request.reservation;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import com.antmen.antwork.common.domain.entity.reservation.Reservation;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.List;
 
 @Getter
 @Setter
 @Builder
 @ToString
+@AllArgsConstructor
+@NoArgsConstructor
 public class MatchingRequestDto {
     private Long reservationId;
     private Long addressId;                         // 기본 주소 ID (프론트에서 선택)
     private LocalDate reservationDate;              // 예약 날짜
     private LocalTime reservationTime;              // 예약 시간
     private short reservationDuration;              // 서비스 최종 제공 시간
+
+    public static MatchingRequestDto from(Reservation reservation) {
+        return MatchingRequestDto.builder()
+                .reservationId(reservation.getReservationId())
+                .addressId(reservation.getAddress().getAddressId())
+                .reservationDate(reservation.getReservationDate())
+                .reservationTime(reservation.getReservationTime())
+                .reservationDuration(reservation.getReservationDuration())
+                .build();
+    }
+
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/api/request/reservation/PaymentRequestDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/request/reservation/PaymentRequestDto.java
@@ -1,13 +1,13 @@
 package com.antmen.antwork.common.api.request.reservation;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PaymentRequestDto {
     @NotNull
     private Long reservationId;        // 예약 번호 (엔티티와 타입 일치)

--- a/m-common/src/main/java/com/antmen/antwork/common/api/request/reservation/ReservationRequestDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/request/reservation/ReservationRequestDto.java
@@ -1,9 +1,8 @@
 package com.antmen.antwork.common.api.request.reservation;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.Builder;
+import lombok.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -12,6 +11,8 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReservationRequestDto {
     private Long customerId;                        // 수요자 아이디
     private Long categoryId;                        // 카테고리 번호

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingConsumerService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingConsumerService.java
@@ -9,6 +9,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -17,18 +19,29 @@ public class MatchingConsumerService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
     private final MatchingService matchingService;
-    @Scheduled(fixedDelay = 2000) // 2초마다 큐 polling
+
+    @Scheduled(fixedDelay = 2000)
     public void consume() {
         Object raw = redisTemplate.opsForList().leftPop("matching:queue");
         if (raw == null) return;
 
         try {
-            MatchingRequestDto dto = objectMapper.convertValue(raw, MatchingRequestDto.class);
-            log.info("📥 Redis 큐에서 매칭 요청 수신: {}", dto.getReservationId());
+            String json = (String) raw;
+            MatchingRequestDto dto = objectMapper.readValue(json, MatchingRequestDto.class);
+
+            LocalDateTime startTime = LocalDateTime.now();
+            long start = System.currentTimeMillis();
+
+            log.info("📥 [{}] Redis 큐에서 매칭 요청 수신: reservationId={}", startTime, dto.getReservationId());
 
             matchingService.createInitialMatchingFromDto(dto);
+
+            long end = System.currentTimeMillis();
+            long duration = end - start;
+            log.info("✅ [{}] 매칭 처리 완료: reservationId={}, 처리시간={}ms", LocalDateTime.now(), dto.getReservationId(), duration);
+
         } catch (Exception e) {
-            log.error("❌ 매칭 처리 실패: {}", e.getMessage(), e);
+            log.error("❌ [{}] 매칭 처리 실패: {}", LocalDateTime.now(), e.getMessage(), e);
         }
     }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/PaymentServiceImpl.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/PaymentServiceImpl.java
@@ -1,7 +1,9 @@
 package com.antmen.antwork.common.service.serviceReservation;
 
+import com.antmen.antwork.common.api.request.reservation.MatchingRequestDto;
 import com.antmen.antwork.common.api.request.reservation.PaymentRequestDto;
 import com.antmen.antwork.common.domain.entity.AlertTrigger;
+import com.antmen.antwork.common.domain.entity.reservation.Matching;
 import com.antmen.antwork.common.domain.entity.reservation.Payment;
 import com.antmen.antwork.common.domain.entity.reservation.PaymentStatus;
 import com.antmen.antwork.common.domain.entity.reservation.Reservation;
@@ -10,12 +12,15 @@ import com.antmen.antwork.common.infra.repository.reservation.PaymentRepository;
 import com.antmen.antwork.common.infra.repository.reservation.ReservationRepository;
 import com.antmen.antwork.common.service.AlertService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentServiceImpl implements PaymentService {
@@ -23,6 +28,7 @@ public class PaymentServiceImpl implements PaymentService {
     private final PaymentRepository paymentRepository;
     private final ReservationRepository reservationRepository;
     private final AlertService alertService;
+    private final MatchingService matchingService;
 
     @Override
     @Transactional
@@ -43,21 +49,43 @@ public class PaymentServiceImpl implements PaymentService {
         if (!reservation.getReservationAmount().equals(requestDto.getPayAmount())) {
             throw new IllegalArgumentException("결제 금액이 예약 금액과 일치하지 않습니다.");
         }
+
         Payment payment = savePaymentInfo(requestDto);
         updatePaymentStatus(payment, PaymentStatus.DONE);
+
+        // ✅ 기존 방식 매칭 처리 시간 로그
+        MatchingRequestDto matchingDto = MatchingRequestDto.from(reservation);
+        long start = System.currentTimeMillis();
+        log.info("📥 [동기] 매칭 처리 시작: reservationId={}", matchingDto.getReservationId());
+
+        matchingService.createInitialMatchingFromDto(matchingDto);
+
+        long end = System.currentTimeMillis();
+        log.info("✅ [동기] 매칭 처리 완료: reservationId={}, 처리시간={}ms", matchingDto.getReservationId(), (end - start));
+
+        // 알림
+        if (!reservation.getMatchings().isEmpty()) {
+            alertService.sendAlert(reservation.getMatchings().get(0).getManager().getUserId(),
+                    AlertTrigger.MATCHING_REQUEST_TO_MANAGER,
+                    reservation.getReservationId());
+        } else {
+            log.warn("❗ 매칭 리스트가 비어 있어 알림을 전송하지 않습니다. reservationId={}", reservation.getReservationId());
+        }
+
+        alertService.sendAlert(reservation.getCustomer().getUserId(),
+                AlertTrigger.RESERVATION_CONFIRMED,
+                reservation.getReservationId());
 
         String response = String.format(
                 "{\"message\": \"결제 요청이 성공적으로 저장되었습니다.\", \"paymentId\": %d}",
                 payment.getPayId()
         );
 
-        alertService.sendAlert(reservation.getMatchings().get(0).getManager().getUserId(), AlertTrigger.MATCHING_REQUEST_TO_MANAGER, reservation.getReservationId());
-        alertService.sendAlert(reservation.getCustomer().getUserId(),AlertTrigger.RESERVATION_CONFIRMED,reservation.getReservationId());
-
         return ResponseEntity.ok()
                 .header("Content-Type", "application/json")
                 .body(response);
     }
+
 
     @Override
     @Transactional


### PR DESCRIPTION
- 매칭 요청 시 Redis 큐에 적재하도록 구조 변경
- @Scheduled 기반 소비자에서 처리 시간(ms) 로그 출력
- 기존 동기 처리 방식에도 처리 시간 로그 추가
- 알림 전송 시 매칭 리스트가 비어있을 경우 WARN 로그 출력